### PR TITLE
Fix typo and redundent item in SdkComboBox 

### DIFF
--- a/src/main/kotlin/io/xmake/project/XMakeNewProjectPanel.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeNewProjectPanel.kt
@@ -59,7 +59,12 @@ class XMakeNewProjectPanel : Disposable {
             if (xmakeProgram != null) {
                 sdkModel.addSdk(XMakeSdkType.instance, xmakeProgram, null)
             }
-            val myJdkComboBox = SdkComboBox(SdkComboBoxModel.createSdkComboBoxModel(project, sdkModel))
+            val myJdkComboBox = SdkComboBox(SdkComboBoxModel.createSdkComboBoxModel(
+                project,
+                sdkModel,
+                {sdk -> sdk is XMakeSdkType},
+                {sdk -> sdk is XMakeSdkType},)
+            )
             cell(myJdkComboBox).align(AlignX.FILL)
         }
         row("Module Language:") {

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -60,7 +60,7 @@ class XMakeRunConfigurationEditor(private val project: Project) : SettingsEditor
             cell(targetsComboBox).align(AlignX.FILL)
         }
 
-        row("Environment variables:") {
+        row("Program arguments:") {
             cell(runArguments).align(AlignX.FILL)
         }
         row(environmentVariables.label) {


### PR DESCRIPTION
- Remove redundent **SDK** item in **SdkComboBox** while xmake utilities are presented in the popup list.
- Correct the title of **Program Arguments** field in RunConfiguration.

