### PR TITLE
Chore to add 'Deprecated' tag to mark for deletion

### DIFF
--- a/src/main/kotlin/io/xmake/project/XMakeConfigData.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeConfigData.kt
@@ -2,6 +2,7 @@ package io.xmake.project
 
 import io.xmake.project.toolkit.Toolkit
 
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 data class XMakeConfigData(
     val languagesModel: String,
     val kindsModel: String,

--- a/src/main/kotlin/io/xmake/project/XMakeDirectoryProjectGenerator.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeDirectoryProjectGenerator.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.runBlocking
 import java.io.File
 import javax.swing.Icon
 
-
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 class XMakeDirectoryProjectGenerator :
     DirectoryProjectGeneratorBase<XMakeConfigData>(), CustomStepProjectGenerator<XMakeConfigData> {
 

--- a/src/main/kotlin/io/xmake/project/XMakeModuleBuilder.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeModuleBuilder.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import java.io.File
 
-
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 class XMakeModuleBuilder : ModuleBuilder() {
     lateinit var configurationData: XMakeConfigData
 

--- a/src/main/kotlin/io/xmake/project/XMakeModuleType.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeModuleType.kt
@@ -2,11 +2,11 @@ package io.xmake.project
 
 import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.module.ModuleTypeManager
-import org.jetbrains.jps.model.module.JpsModuleSourceRootType
 import io.xmake.icons.XMakeIcons
+import org.jetbrains.jps.model.module.JpsModuleSourceRootType
+import javax.swing.Icon
 
-import javax.swing.*
-
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 class XMakeModuleType : ModuleType<XMakeModuleBuilder>(MODULE_TYPE) {
 
     override fun createModuleBuilder(): XMakeModuleBuilder {

--- a/src/main/kotlin/io/xmake/project/XMakeNewProjectPanel.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeNewProjectPanel.kt
@@ -12,6 +12,7 @@ import io.xmake.project.toolkit.ui.ToolkitComboBox
 import io.xmake.project.toolkit.ui.ToolkitListItem
 import javax.swing.DefaultComboBoxModel
 
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 class XMakeNewProjectPanel : Disposable {
 
     // the module kinds

--- a/src/main/kotlin/io/xmake/project/XMakeProjectGeneratorPeer.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeProjectGeneratorPeer.kt
@@ -6,6 +6,7 @@ import com.intellij.platform.GeneratorPeerImpl
 import com.intellij.ui.dsl.builder.panel
 import javax.swing.JComponent
 
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 class XMakeProjectGeneratorPeer : GeneratorPeerImpl<XMakeConfigData>() {
 
     private val newProjectPanel = XMakeNewProjectPanel()

--- a/src/main/kotlin/io/xmake/project/XMakeProjectSettingsStep.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeProjectSettingsStep.kt
@@ -3,5 +3,6 @@ import com.intellij.ide.util.projectWizard.AbstractNewProjectStep
 import com.intellij.ide.util.projectWizard.ProjectSettingsStepBase
 import com.intellij.platform.DirectoryProjectGenerator
 
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 open class XMakeProjectSettingsStep(generator: DirectoryProjectGenerator<XMakeConfigData>)
     : ProjectSettingsStepBase<XMakeConfigData>(generator, AbstractNewProjectStep.AbstractCallback())

--- a/src/main/kotlin/io/xmake/project/XMakeSdkSettingsStep.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeSdkSettingsStep.kt
@@ -6,13 +6,14 @@ import com.intellij.ide.util.projectWizard.ModuleWizardStep
 import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModifiableRootModel
-import com.intellij.ui.dsl.builder.*
-import javax.swing.JComponent
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBEmptyBorder
-import io.xmake.project.toolkit.ToolkitHostType.*
+import io.xmake.project.toolkit.ToolkitHostType.SSH
+import io.xmake.project.toolkit.ToolkitHostType.WSL
+import javax.swing.JComponent
 
-
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
 class XMakeSdkSettingsStep(
     private val context: WizardContext,
     private val configurationUpdaterConsumer: ((ModuleBuilder.ModuleConfigurationUpdater) -> Unit)? = null

--- a/src/main/kotlin/io/xmake/project/XMakeSdkType.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeSdkType.kt
@@ -1,17 +1,13 @@
 package io.xmake.project
 
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.projectRoots.SdkType
-import com.intellij.openapi.projectRoots.SdkAdditionalData
-import com.intellij.openapi.projectRoots.SdkModificator
-import com.intellij.openapi.projectRoots.SdkModel
-import com.intellij.openapi.projectRoots.AdditionalDataConfigurable
-import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.*
 import io.xmake.icons.XMakeIcons
-import org.jdom.Element
 import io.xmake.utils.SystemUtils
+import org.jdom.Element
 import javax.swing.Icon
 
+@Deprecated("Please refer to the relevant content in folder io/xmake/project/toolkit.")
 class XMakeSdkType : SdkType("XMake SDK") {
 
     override fun suggestHomePath(): String? {

--- a/src/main/kotlin/io/xmake/utils/ConsoleProcessHandler.kt
+++ b/src/main/kotlin/io/xmake/utils/ConsoleProcessHandler.kt
@@ -1,14 +1,16 @@
 package io.xmake.utils
 
-import com.intellij.execution.process.*
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.KillableColoredProcessHandler
+import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.Key
-import com.intellij.execution.configurations.GeneralCommandLine
 import java.io.IOException
 import java.io.OutputStreamWriter
 
+@Deprecated("Please refer to runProcessWithHandler.")
 class ConsoleProcessHandler(
     private val consoleView: ConsoleView,
     commandLine: GeneralCommandLine,

--- a/src/main/kotlin/io/xmake/utils/SystemUtils.kt
+++ b/src/main/kotlin/io/xmake/utils/SystemUtils.kt
@@ -22,8 +22,11 @@ import java.util.regex.Pattern
 
 object SystemUtils {
 
+    @Deprecated("Please refer to the relevant content in folder io/xmake/project/toolkit.")
     // the xmake program
     private var _xmakeProgram: String = ""
+
+    @Deprecated("Please refer to the relevant content in folder io/xmake/project/toolkit.")
     var xmakeProgram: String
         get() {
 
@@ -61,8 +64,11 @@ object SystemUtils {
             _xmakeProgram = value
         }
 
+    @Deprecated("Please refer to the relevant content in folder io/xmake/project/toolkit.")
     // the xmake version
     private var _xmakeVersion: String = ""
+
+    @Deprecated("Please refer to the relevant content in folder io/xmake/project/toolkit.")
     var xmakeVersion: String
         get() {
             if (_xmakeVersion == "") {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -28,11 +28,6 @@
         <!-- icons -->
         <iconProvider implementation="io.xmake.icons.XMakeIconProvider"/>
 
-        <!-- module configurations -->
-        <!-- clion not support -->
-        <!--        <sdkType implementation="io.xmake.project.XMakeSdkType"/>-->
-        <!--        <moduleBuilder builderClass="io.xmake.project.XMakeModuleBuilder"/>-->
-        <!--        <directoryProjectGenerator implementation="io.xmake.project.XMakeDirectoryProjectGenerator"/>-->
         <!-- module-based IDE-->
         <moduleBuilder builderClass="io.xmake.project.wizard.XMakeProjectModuleBuilder"/>
         <!-- directory-based IDE-->


### PR DESCRIPTION
- Tagged legacy code as `@Deprecated` for safe deletion.
- Removed unnecessary references and comments from plugin.xml.