### PR TITLE
Fix compatibility issues with extension to XMake toolkit host

### DIFF
--- a/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
@@ -12,9 +12,8 @@ import io.xmake.project.xmakeConsoleView
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
-import io.xmake.utils.execute.SyncDirection
-import io.xmake.utils.execute.syncFileByToolkit
-import kotlinx.coroutines.GlobalScope
+import io.xmake.utils.execute.fetchGeneratedFile
+import io.xmake.utils.execute.syncBeforeFetch
 
 class UpdateCmakeListsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -31,6 +30,8 @@ class UpdateCmakeListsAction : AnAction() {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessAdapter() {
                         override fun processTerminated(e: ProcessEvent) {
+                            syncBeforeFetch(project, project.activatedToolkit!!)
+
                             SystemUtils.runvInConsole(
                                 project,
                                 xmakeConfiguration.updateCmakeListsCommandLine,
@@ -40,13 +41,7 @@ class UpdateCmakeListsAction : AnAction() {
                             )?.addProcessListener(
                                 object : ProcessAdapter() {
                                     override fun processTerminated(e: ProcessEvent) {
-                                        syncFileByToolkit(
-                                            GlobalScope,
-                                            project,
-                                            project.activatedToolkit!!,
-                                            "CMakeLists.txt",
-                                            SyncDirection.UPSTREAM_TO_LOCAL
-                                        )
+                                        fetchGeneratedFile(project, project.activatedToolkit!!, "CMakeLists.txt")
                                         // Todo: Reload from disks after download from remote.
                                     }
                                 }
@@ -59,13 +54,7 @@ class UpdateCmakeListsAction : AnAction() {
                     ?.addProcessListener(
                         object : ProcessAdapter() {
                             override fun processTerminated(e: ProcessEvent) {
-                                syncFileByToolkit(
-                                    GlobalScope,
-                                    project,
-                                    project.activatedToolkit!!,
-                                    "CMakeLists.txt",
-                                    SyncDirection.UPSTREAM_TO_LOCAL
-                                )
+                                fetchGeneratedFile(project, project.activatedToolkit!!, "CMakeLists.txt")
                             }
                         }
                     )

--- a/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
@@ -12,9 +12,8 @@ import io.xmake.project.xmakeConsoleView
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
-import io.xmake.utils.execute.SyncDirection
-import io.xmake.utils.execute.syncFileByToolkit
-import kotlinx.coroutines.GlobalScope
+import io.xmake.utils.execute.fetchGeneratedFile
+import io.xmake.utils.execute.syncBeforeFetch
 
 class UpdateCompileCommandsAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -31,6 +30,8 @@ class UpdateCompileCommandsAction : AnAction() {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessAdapter() {
                         override fun processTerminated(e: ProcessEvent) {
+                            syncBeforeFetch(project, project.activatedToolkit!!)
+
                             SystemUtils.runvInConsole(
                                 project,
                                 xmakeConfiguration.updateCompileCommansLine,
@@ -41,12 +42,10 @@ class UpdateCompileCommandsAction : AnAction() {
                                 ?.addProcessListener(
                                     object : ProcessAdapter() {
                                         override fun processTerminated(e: ProcessEvent) {
-                                            syncFileByToolkit(
-                                                GlobalScope,
+                                            fetchGeneratedFile(
                                                 project,
                                                 project.activatedToolkit!!,
-                                                "compile_commands.json",
-                                                SyncDirection.UPSTREAM_TO_LOCAL
+                                                "compile_commands.json"
                                             )
                                             // Todo: Reload from disks after download from remote.
                                         }
@@ -60,13 +59,7 @@ class UpdateCompileCommandsAction : AnAction() {
                     ?.addProcessListener(
                         object : ProcessAdapter() {
                             override fun processTerminated(e: ProcessEvent) {
-                                syncFileByToolkit(
-                                    GlobalScope,
-                                    project,
-                                    project.activatedToolkit!!,
-                                    "compile_commands.json",
-                                    SyncDirection.UPSTREAM_TO_LOCAL
-                                )
+                                fetchGeneratedFile(project, project.activatedToolkit!!, "compile_commands.json")
                             }
                         }
                     )

--- a/src/main/kotlin/io/xmake/icons/XMakeIcons.kt
+++ b/src/main/kotlin/io/xmake/icons/XMakeIcons.kt
@@ -1,6 +1,6 @@
 package io.xmake.icons
 
-import com.intellij.icons.ExpUiIcons
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.IconLoader
 import javax.swing.Icon
 
@@ -13,10 +13,10 @@ object XMakeIcons {
     val FILE = load("/icons/xmake.svg")
 
     // error icon
-    val ERROR = ExpUiIcons.Status.Error
+    val ERROR = AllIcons.General.Error
 
     // warning icon
-    val WARNING = ExpUiIcons.Status.Warning
+    val WARNING = AllIcons.General.Warning
 
     private fun load(path: String): Icon = IconLoader.getIcon(path, XMakeIcons::class.java)
 

--- a/src/main/kotlin/io/xmake/project/XMakeSdkSettingsStep.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeSdkSettingsStep.kt
@@ -9,8 +9,6 @@ import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBEmptyBorder
-import io.xmake.project.toolkit.ToolkitHostType.SSH
-import io.xmake.project.toolkit.ToolkitHostType.WSL
 import javax.swing.JComponent
 
 @Deprecated("Please refer to the relevant content in folder io/xmake/project/wizard.")
@@ -53,7 +51,7 @@ class XMakeSdkSettingsStep(
             }
 
             // Todo: Check whether working directory is valid.
-            if ((toolkit.host.type == WSL || toolkit.host.type == SSH) && remotePath.isNullOrBlank()) {
+            if ((toolkit.isOnRemote) && remotePath.isNullOrBlank()) {
                 throw RuntimeConfigurationError("Working directory is not set!")
             }
         }

--- a/src/main/kotlin/io/xmake/project/wizard/XMakeProjectWizardStep.kt
+++ b/src/main/kotlin/io/xmake/project/wizard/XMakeProjectWizardStep.kt
@@ -3,7 +3,6 @@ package io.xmake.project.wizard
 import com.intellij.execution.RunManager
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessNotCreatedException
-import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.ide.util.projectWizard.ModuleBuilder
 import com.intellij.ide.util.projectWizard.WizardContext
 import com.intellij.ide.wizard.AbstractNewProjectWizardStep
@@ -23,7 +22,6 @@ import com.intellij.openapi.ui.shortenTextWithEllipsis
 import com.intellij.openapi.ui.validation.*
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.project.stateStore
-import com.intellij.ssh.config.unified.SshConfig
 import com.intellij.ui.UIBundle
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.util.getTextWidth
@@ -38,8 +36,10 @@ import io.xmake.project.toolkit.ui.ToolkitComboBox.Companion.forToolkitComboBox
 import io.xmake.project.wizard.XMakeNewProjectWizardData.Companion.xmakeData
 import io.xmake.run.XMakeRunConfiguration
 import io.xmake.run.XMakeRunConfigurationType
-import io.xmake.utils.execute.*
-import kotlinx.coroutines.CoroutineScope
+import io.xmake.utils.execute.SyncDirection
+import io.xmake.utils.execute.createProcess
+import io.xmake.utils.execute.runProcess
+import io.xmake.utils.execute.transferFolderByToolkit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import java.io.File
@@ -50,8 +50,8 @@ import kotlin.io.path.Path
 class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
     AbstractNewProjectWizardStep(parent),
     XMakeNewProjectWizardData {
+
     private val toolkitManager = ToolkitManager.getInstance()
-    private val scope = CoroutineScope(Dispatchers.IO)
 
     override val nameProperty: GraphProperty<String> = baseData!!.nameProperty
     override val pathProperty: GraphProperty<String> = baseData!!.pathProperty
@@ -165,14 +165,14 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
 
     override fun setupProject(project: Project) {
         if (context.isCreatingNewProject) {
-            val workingDirectory = when (toolkit!!.host.type) {
-                LOCAL -> File(contentEntryPath).path
-                WSL, SSH -> remoteContentEntryPath
-            }
-            val generateDirectory = when (toolkit!!.host.type) {
-                LOCAL -> File("$contentEntryPath.tmpdir").path
-                WSL, SSH -> remoteContentEntryPath
-            }
+            val workingDirectory =
+                if (!toolkit!!.isOnRemote) File(contentEntryPath).path
+                else remoteContentEntryPath
+
+            val generateDirectory =
+                if (!toolkit!!.isOnRemote) File("$contentEntryPath.tmpdir").path
+                else remoteContentEntryPath
+
 
             Log.info("contentEntry path: $contentEntryPath")
             Log.info("remote contentEntry path: $remoteContentEntryPath")
@@ -214,24 +214,8 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
                         }
                     }
 
-                    WSL -> {
-                        syncProjectByWslSync(
-                            scope,
-                            project,
-                            host.target as WSLDistribution,
-                            workingDirectory,
-                            SyncDirection.UPSTREAM_TO_LOCAL
-                        )
-                    }
-
-                    SSH -> {
-                        syncProjectBySftp(
-                            scope,
-                            project,
-                            host.target as SshConfig,
-                            workingDirectory,
-                            SyncDirection.UPSTREAM_TO_LOCAL
-                        )
+                    WSL, SSH -> {
+                        transferFolderByToolkit(project, this, SyncDirection.UPSTREAM_TO_LOCAL, workingDirectory, null)
                     }
                 }
             }

--- a/src/main/kotlin/io/xmake/project/wizard/XMakeProjectWizardStep.kt
+++ b/src/main/kotlin/io/xmake/project/wizard/XMakeProjectWizardStep.kt
@@ -66,8 +66,8 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
     private val isOnRemoteProperty: GraphProperty<Boolean> =
         propertyGraph.lazyProperty { toolkit?.isOnRemote == true }
 
-    override var name: String = baseData!!.name
-    override var path: String = baseData!!.path
+    override var name: String by nameProperty
+    override var path: String by pathProperty
     override var remotePath: String by remotePathProperty
     override var language: String by languagesProperty
     override var kind: String by kindsProperty
@@ -104,7 +104,6 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
     private val browser = DirectoryBrowser(context.project)
     private val toolkitComboBox = ToolkitComboBox(::toolkit)
 
-    @Suppress("UnstableApiUsage")
     override fun setupUI(builder: Panel) {
         val locationProperty = remotePathProperty.joinCanonicalPath(nameProperty)
         with(builder) {

--- a/src/main/kotlin/io/xmake/run/XMakeDefaultRunner.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeDefaultRunner.kt
@@ -1,26 +1,18 @@
 package io.xmake.run
 
-import com.intellij.execution.ExecutionManager
-import com.intellij.execution.configurations.RunProfile
 import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.configurations.RunnerSettings
-import com.intellij.execution.executors.DefaultRunExecutor
-import com.intellij.execution.runners.*
+import com.intellij.execution.runners.AsyncProgramRunner
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.runners.executeState
 import com.intellij.execution.ui.RunContentDescriptor
-import com.intellij.openapi.diagnostic.Logger
+import org.jetbrains.concurrency.Promise
 import org.jetbrains.concurrency.resolvedPromise
-import java.util.concurrent.ExecutionException
-import kotlin.jvm.Throws
 
-abstract class XMakeDefaultRunner : ProgramRunner<RunnerSettings> {
+abstract class XMakeDefaultRunner : AsyncProgramRunner<RunnerSettings>() {
 
-    @Throws(ExecutionException::class)
-    override fun execute(environment: ExecutionEnvironment) {
-        val state = environment.state ?: return
-        @Suppress("UnstableApiUsage")
-        ExecutionManager.getInstance(environment.project).startRunProfile(environment) {
-            resolvedPromise(doExecute(state, environment))
-        }
+    override fun execute(environment: ExecutionEnvironment, state: RunProfileState): Promise<RunContentDescriptor?> {
+        return resolvedPromise(doExecute(state, environment))
     }
     protected open fun doExecute(state: RunProfileState, environment: ExecutionEnvironment) : RunContentDescriptor? {
         return executeState(state, environment, this)

--- a/src/main/kotlin/io/xmake/utils/execute/Sync.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/Sync.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.wsl.target.WslTargetEnvironment
 import com.intellij.execution.wsl.target.WslTargetEnvironmentConfiguration
 import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
 import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.diagnostic.fileLogger
 import com.intellij.openapi.extensions.ExtensionPointName
@@ -146,7 +147,13 @@ fun transferFolderByToolkit(
 ) {
 
     when (toolkit.host.type) {
-        ToolkitHostType.LOCAL -> {}
+        ToolkitHostType.LOCAL -> {
+            invokeLater {
+                runWriteAction {
+                    VirtualFileManager.getInstance().syncRefresh()
+                }
+            }
+        }
         ToolkitHostType.WSL -> {
             syncProjectByWslSync(
                 scope,

--- a/src/main/kotlin/io/xmake/utils/extension/SshToolkitHostExtensionImpl.kt
+++ b/src/main/kotlin/io/xmake/utils/extension/SshToolkitHostExtensionImpl.kt
@@ -1,0 +1,207 @@
+package io.xmake.utils.extension
+
+import ai.grazie.utils.tryRunWithException
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.diagnostic.runAndLogException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.progress.util.ProgressIndicatorBase
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.text.Formats
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.ssh.*
+import com.intellij.ssh.channels.SftpChannel
+import com.intellij.ssh.config.unified.SshConfig
+import com.intellij.ssh.config.unified.SshConfigManager
+import com.intellij.ssh.interaction.PlatformSshPasswordProvider
+import com.intellij.ssh.ui.sftpBrowser.RemoteBrowserDialog
+import com.intellij.ssh.ui.sftpBrowser.SftpRemoteBrowserProvider
+import io.xmake.project.directory.ui.DirectoryBrowser
+import io.xmake.project.toolkit.Toolkit
+import io.xmake.project.toolkit.ToolkitHost
+import io.xmake.project.toolkit.ToolkitHostType
+import io.xmake.utils.execute.SyncDirection
+import io.xmake.utils.execute.rmRecur
+import kotlinx.coroutines.*
+import java.awt.event.ActionListener
+import java.io.File
+import kotlin.io.path.Path
+
+class SshToolkitHostExtensionImpl : ToolkitHostExtension {
+
+    override val KEY: String = "SSH"
+
+    private val sshConfigManager = SshConfigManager.getInstance(null)
+
+    override fun getHostType(): String {
+        return "SSH"
+    }
+
+    override fun getToolkitHosts(project: Project?): List<ToolkitHost> {
+        return sshConfigManager.configs.map {
+            ToolkitHost(ToolkitHostType.SSH, it)
+        }
+    }
+
+    override fun filterRegistered(): (Toolkit) -> Boolean {
+        return { it.isOnRemote }
+    }
+
+    override fun createToolkit(host: ToolkitHost, path: String, version: String): Toolkit {
+        val sshConfig = (host.target as? SshConfig) ?: throw IllegalArgumentException()
+        val name = sshConfig.presentableShortName
+        return Toolkit(name, host, path, version)
+    }
+
+    override fun syncProject(
+        scope: CoroutineScope,
+        project: Project,
+        host: ToolkitHost,
+        direction: SyncDirection,
+        remoteDirectory: String,
+    ) {
+        val sshConfig = (host.target as? SshConfig) ?: throw IllegalArgumentException()
+
+        ProgressManager.getInstance().runProcessWithProgressAsynchronously(
+            object : Task.Backgroundable(project, "Sync directory", true) {
+                override fun run(indicator: ProgressIndicator) {
+                    val commandString = SftpChannelConfig.SftpCommand.detectSftpCommandString
+                    Log.info("Command: $commandString")
+
+                    val builder = ConnectionBuilder(sshConfig.host)
+                        .withSshPasswordProvider(PlatformSshPasswordProvider(sshConfig.copyToCredentials()))
+
+                    val sourceRoots = ProjectRootManager.getInstance(project).contentRoots
+                    Log.info("Source roots: $sourceRoots")
+                    Log.info("guessProjectDir: " + project.guessProjectDir())
+
+                    scope.launch {
+                        val sftpChannel = builder.openFailSafeSftpChannel()
+                        Log.info("sftpChannel.home" + sftpChannel.home)
+
+                        when (direction) {
+                            SyncDirection.LOCAL_TO_UPSTREAM -> {
+
+                                Log.runAndLogException {
+                                    tryRunWithException<SftpChannelNoSuchFileException, List<SftpChannel.FileInfo>> {
+                                        sftpChannel.ls(
+                                            remoteDirectory
+                                        )
+                                    }
+                                        .also { Log.info("before: $it") }
+                                    sftpChannel.rmRecur(remoteDirectory)
+                                    Log.info("after: " + sftpChannel.ls("Project"))
+                                }
+
+                                sftpChannel.uploadFileOrDir(
+                                    File(project.guessProjectDir()?.path ?: ""),
+                                    remoteDir = remoteDirectory, relativePath = "/",
+                                    progressTracker = object : SftpProgressTracker {
+                                        override val isCanceled: Boolean
+                                            get() = false
+                                        //                TODO("Not yet implemented")
+
+                                        override fun onBytesTransferred(count: Long) {
+                                            println("onBytesTransferred(${Formats.formatFileSize(count)})")
+                                        }
+
+                                        override fun onFileCopied(file: File) {
+                                            println("onFileCopied($file)")
+                                        }
+                                    }, filesFilter = { file ->
+                                        mutableListOf(".xmake", ".idea", "build", ".gitignore")
+                                            .all {
+                                                !file.startsWith(
+                                                    Path(
+                                                        project.guessProjectDir()?.path ?: "",
+                                                        it
+                                                    ).toFile()
+                                                )
+                                            }
+                                    }, persistExecutableBit = true
+                                )
+                            }
+
+                            SyncDirection.UPSTREAM_TO_LOCAL -> {
+                                sftpChannel.downloadFileOrDir(remoteDirectory, project.guessProjectDir()?.path ?: "")
+                            }
+                        }
+                        sftpChannel.close()
+
+                        withContext(Dispatchers.EDT) {
+                            runWriteAction {
+                                VirtualFileManager.getInstance().syncRefresh()
+                            }
+                        }
+
+                    }
+                }
+
+                override fun onCancel() {}
+
+                override fun onFinished() {}
+            },
+            ProgressIndicatorBase()
+        )
+    }
+
+    override suspend fun ToolkitHost.loadTargetX(project: Project?) = coroutineScope {
+        target = SshConfigManager.getInstance(project).findConfigById(id!!)!!
+    }
+
+    override fun getTargetId(target: Any?): String {
+        val sshConfig = target as? SshConfig ?: throw IllegalArgumentException()
+        return sshConfig.id
+    }
+
+    override fun DirectoryBrowser.createBrowseListener(host: ToolkitHost): ActionListener {
+        val sshConfig = host.target as? SshConfig ?: throw IllegalArgumentException()
+
+        val sftpChannel = runBlocking(Dispatchers.Default) {
+            ConnectionBuilder(sshConfig.host)
+                .withSshPasswordProvider(PlatformSshPasswordProvider(sshConfig.copyToCredentials()))
+                .openFailSafeSftpChannel()
+        }
+        val sftpRemoteBrowserProvider = SftpRemoteBrowserProvider(sftpChannel)
+        val remoteBrowseFolderListener = ActionListener {
+            text = RemoteBrowserDialog(
+                sftpRemoteBrowserProvider,
+                project,
+                true,
+                withCreateDirectoryButton = true
+            ).apply { showAndGet() }.getResult()
+        }
+        return remoteBrowseFolderListener
+    }
+
+    override fun GeneralCommandLine.createProcess(host: ToolkitHost): Process {
+
+        val sshConfig = host.target as? SshConfig ?: throw IllegalArgumentException()
+
+        val builder = ConnectionBuilder(sshConfig.host)
+            .withSshPasswordProvider(PlatformSshPasswordProvider(sshConfig.copyToCredentials()))
+
+        val command = GeneralCommandLine("sh").withParameters("-c")
+            .withParameters(this.commandLineString)
+            .withWorkDirectory(workDirectory)
+            .withCharset(charset)
+            .withEnvironment(environment)
+            .withInput(inputFile)
+            .withRedirectErrorStream(isRedirectErrorStream)
+
+        return builder
+            .also { Log.info("commandOnRemote: ${command.commandLineString}") }
+            .processBuilder(command)
+            .start()
+    }
+
+    companion object {
+        private val Log = logger<SshToolkitHostExtensionImpl>()
+    }
+}

--- a/src/main/kotlin/io/xmake/utils/extension/ToolkitHostExtension.kt
+++ b/src/main/kotlin/io/xmake/utils/extension/ToolkitHostExtension.kt
@@ -1,0 +1,38 @@
+package io.xmake.utils.extension
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.openapi.project.Project
+import io.xmake.project.directory.ui.DirectoryBrowser
+import io.xmake.project.toolkit.Toolkit
+import io.xmake.project.toolkit.ToolkitHost
+import io.xmake.utils.execute.SyncDirection
+import kotlinx.coroutines.CoroutineScope
+import java.awt.event.ActionListener
+
+interface ToolkitHostExtension {
+    val KEY: String
+
+    fun getHostType(): String
+
+    fun getToolkitHosts(project: Project? = null): List<ToolkitHost>
+
+    fun filterRegistered(): (Toolkit) -> Boolean
+
+    fun createToolkit(host: ToolkitHost, path: String, version: String): Toolkit
+
+    fun syncProject(
+        scope: CoroutineScope,
+        project: Project,
+        host: ToolkitHost,
+        direction: SyncDirection,
+        remoteDirectory: String,
+    )
+
+    fun getTargetId(target: Any? = null): String
+
+    suspend fun ToolkitHost.loadTargetX(project: Project? = null)
+
+    fun DirectoryBrowser.createBrowseListener(host: ToolkitHost): ActionListener
+
+    fun GeneralCommandLine.createProcess(target: ToolkitHost): Process
+}

--- a/src/main/resources/META-INF/io.xmake-ssh.xml
+++ b/src/main/resources/META-INF/io.xmake-ssh.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="io.xmake">
+        <toolkitHostExtension implementation="io.xmake.utils.extension.SshToolkitHostExtensionImpl"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/io.xmake-ultimate.xml
+++ b/src/main/resources/META-INF/io.xmake-ultimate.xml
@@ -1,2 +1,0 @@
-<idea-plugin>
-</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -4,6 +4,11 @@
     <name>XMake</name>
     <vendor email="waruqi@gmail.com" url="https://xmake.io">xmake.io</vendor>
 
+    <extensionPoints>
+        <extensionPoint name="toolkitHostExtension" interface="io.xmake.utils.extension.ToolkitHostExtension"
+                        dynamic="true"/>
+    </extensionPoints>
+
     <!--all-->
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,8 +15,8 @@
     <depends>com.intellij.modules.xml</depends>
     <depends>com.intellij.modules.xdebugger</depends>
 
-    <depends optional="true" config-file="io.xmake-ultimate.xml">
-        com.intellij.modules.ultimate
+    <depends optional="true" config-file="io.xmake-ssh.xml">
+        com.intellij.modules.ssh
     </depends>
     <!--clion and c/cpp language-->
     <!--


### PR DESCRIPTION
#### _What Changes_

- fixed compatibility issues with `ProgramRunner`
- fixed compatibility issues with `Icons`
- added `extension point` to enhance compatibility and support toolkit host extensions
- implemented support for toolkit host extensions and refactor the `sync` function for compatibility
- fixed issue with setting project `name` and `path`
- fixed issue with virtual file refreshment and `reload from disk` automatically

#### _Compatibility_

I have already resolved all the **_Deprecated_** and **_Internal_** API usage issues, but I have, indeed,  added some **_Experimental_** API usage which seems more lenient. So far, the plugin is compatible with both **_commercial_** and **_non-commercial_** versions from `2023.3` to `2024.2`, including `IC`/`IU`/`CL`, etc.

#### _Extendable Host-Type_

I have implemented the `Extension Point` mechanism of the IntelliJ Platform and provided a basic extension interface to support more type of host to run **_XMake_**. It's just a temporary solution proposed more for compatibility issues, which is not a well-extendable extension interface. However, it provides the possibility for this plugin to run **_XMake_** conveniently in `docker` or `dev containers` in the future.

#### _Remote support_

Currently, the `ssh` connection relies on the IDE platform, so the remote use of the **_XMake_** binary is not available on IDEs without `ssh` support. In the future, functions for remote and distributed compilation of XMake may be developed. If achieved, we can choose the appropriate remote connection method to use **_XMake_** for compiling and running, and even integrate ssh with **_XMake_**'s remote functionality to adapt to some special intranet environments.